### PR TITLE
try bundling with scriptc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,4 +46,4 @@ tsconfig.tsbuildinfo
 # Local recording for the ported Corepack suite (NOCK_ENV=record).
 /test/corepack/nocks.db
 
-.pi-subagents
+.pi-subagents.scriptc-work/

--- a/.gitignore
+++ b/.gitignore
@@ -46,4 +46,5 @@ tsconfig.tsbuildinfo
 # Local recording for the ported Corepack suite (NOCK_ENV=record).
 /test/corepack/nocks.db
 
-.pi-subagents.scriptc-work/
+.pi-subagents
+.scriptc-work/

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -9,6 +9,7 @@
     "*.yml",
     "test/corepack/*.test.ts",
     "test/corepack/_registryServer.mjs",
-    "bin/**"
+    "bin/**",
+    ".scriptc-work/**"
   ]
 }

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/oxlint/configuration_schema.json",
   "plugins": ["unicorn", "typescript", "oxc"],
-  "ignorePatterns": ["bin/**"],
+  "ignorePatterns": ["bin/**", ".scriptc-work/**"],
   "rules": {}
 }

--- a/scripts/scriptc/README.md
+++ b/scripts/scriptc/README.md
@@ -1,0 +1,90 @@
+# scriptc feasibility spike
+
+[scriptc](https://github.com/vercel-labs/scriptc) compiles TypeScript to native
+executables with no JS engine in the binary. This asks whether jup could ship
+that way. Measured against **scriptc 0.0.35**.
+
+**Answer: no, and not close.** The blockers are on scriptc's side and are not
+the kind jup can work around. Nothing here changes `src/`.
+
+## Run it
+
+```sh
+npm i -g scriptc          # needs Node >= 24
+node scripts/scriptc/try-build.mjs
+```
+
+Everything lands in `.scriptc-work/` (gitignored). Exits non-zero while the
+divergence in stage 4 stands.
+
+| File | What it is |
+| --- | --- |
+| `try-build.mjs` | The spike: rewrite, coverage, build, and verify against Node |
+| `codemod.mjs` | `src/` → a tree scriptc can parse. Every adaptation is listed in `ADAPTATIONS` |
+| `regex-repro.ts` | Standalone repro of the correctness bug, for filing upstream |
+
+## Blocker 1 — `process.getBuiltinModule` does not exist
+
+Not a missing typing; the name appears nowhere in `@scriptc/compiler`. scriptc
+reaches builtins only via `import … from "node:x"`, which is the form AGENTS.md
+forbids, across **78 call sites**. Cold, jup is 168 preflight errors.
+
+`codemod.mjs` rewrites each site to a namespace import in a derived tree. That
+is fine for a spike and unshippable as a real port — it inverts a house rule
+that exists to keep the warm path's module graph honest.
+
+## Blocker 2 — the surface jup is built on isn't implemented
+
+With blocker 1 gone, **146 errors remain**, all missing runtime members. The
+modules resolve; the members don't:
+
+| Area | Missing |
+| --- | --- |
+| `URL` | `origin`, `username`, `password`, `hash`, `port`, `canParse` — 46 errors, and §05's credential scoping |
+| `crypto` | `verify`, `createPublicKey`, `timingSafeEqual` — §06 signature verification |
+| `zlib` | `createGunzip`, `createGzip`, `createInflate`, `createBrotliDecompress` |
+| `fs` | `createReadStream`/`WriteStream`, `symlinkSync`, `readlinkSync`, `lstat`, `realpath`, `Stats.mode`/`uid` |
+| streams | `Readable.toWeb`, `TransformStream`, `ReadableStream.tee`/`pipeThrough`, `HeadersInit` |
+| misc | `module.runMain`, `util.styleText`, `os.constants`, `process.exitCode` |
+
+By file: `net/proxy.ts` 30, `commands/shims.ts` 19, `net/http.ts` 15,
+`run/native.ts` 12, `cache/tar.ts` 11. Those are registry auth, symlink shims,
+archive extraction and signature verification — jup's whole reason to exist.
+There is no subset of jup worth shipping that avoids them.
+
+## Blocker 3 — what does compile is silently wrong
+
+`src/version/semver.ts` builds: **603 KB, fully static**, no embedded engine,
+against Node's 124 MB. It needs four semantics-neutral edits, all in
+`ADAPTATIONS` — `Number.parseInt` is dynamic-only, a relational compare on a
+`string | number` union won't lower, and `s[i]` under the repo's
+`noUncheckedIndexedAccess` won't either.
+
+It also answers **5 of 11 differential cases wrong**, with exit 0 and no
+diagnostic:
+
+```
+isValidRange("9.x")       node: true   native: false
+isValidRange("^4")        node: true   native: false
+isValidRange(">=18 <21")  node: true   native: false
+isValidRange("*")         node: true   native: false
+```
+
+Cause, minimised in `regex-repro.ts`: a **non-participating capture group reads
+`""` where ECMA-262 specifies `undefined`**.
+
+```
+PARTIAL_RE.exec("4")   node: ["4","4",null,null]   native: ["4","4","",""]
+```
+
+`semver.ts:255` reads an absent component as a wildcard (`isWildcard(match[2])`),
+and `semver.ts:409` does `match[1] ?? "="`. `""` is neither absent nor a
+wildcard, so every partial range becomes a parse failure — silently, in the
+code that decides which package manager version a project gets.
+
+## Revisit when
+
+scriptc grows `process.getBuiltinModule`, `URL`'s auth members, and the
+`crypto`/`zlib`/symlink surface — and the capture-group bug is fixed. Until
+then a compiled binary can't be trusted without a differential harness, which
+is more than the size win is worth.

--- a/scripts/scriptc/codemod.mjs
+++ b/scripts/scriptc/codemod.mjs
@@ -1,0 +1,165 @@
+/**
+ * Rewrite `src/` into a tree scriptc can parse, without touching `src/`.
+ *
+ * scriptc reaches Node builtins only through `import … from "node:x"`. jup's
+ * house rule is the opposite — AGENTS.md, "Never `import` a `node:` builtin" —
+ * and `process.getBuiltinModule` is what scriptc has no notion of at all: not a
+ * missing typing, an absent feature (no mention of the name anywhere in
+ * `@scriptc/compiler`). So the 78 call sites have to become imports somewhere,
+ * and that somewhere is a derived copy: this writes `<out>/`, and `src/` stays
+ * exactly as it ships.
+ *
+ * Every call site becomes a reference to a namespace import rather than a named
+ * one, because the same rewrite then covers all three shapes jup uses without
+ * parsing any of them: the top-level `const { x } = …` destructure, the inline
+ * `process.getBuiltinModule("node:crypto").randomBytes(…)`, and proxy.ts's
+ * `cond ? getBuiltinModule("node:https") : getBuiltinModule("node:http")`.
+ * `const { EOL } = __sc_node_os;` is the same binding it was.
+ *
+ * Two further edits are applied by hand below (`ADAPTATIONS`) — they are not
+ * about builtins but about scriptc's language subset, and they are listed
+ * individually so the PR can name them.
+ *
+ * Usage: `node scripts/scriptc/codemod.mjs <src-dir> <out-dir>`
+ */
+
+import { readdirSync, readFileSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { join, relative, dirname } from "node:path";
+
+const SRC = process.argv[2];
+const OUT = process.argv[3];
+
+if (!SRC || !OUT) {
+  console.error("usage: node scripts/scriptc/codemod.mjs <src-dir> <out-dir>");
+  process.exit(2);
+}
+
+const CALL_RE = /process\.getBuiltinModule\(\s*"(node:[a-z/_]+)"\s*\)/g;
+
+/**
+ * Edits scriptc's *language* subset forces, as opposed to its builtin surface.
+ * Both are semantics-neutral, and both are load-bearing for the one module that
+ * compiles today (`version/semver.ts`), so they live here rather than in prose.
+ */
+const ADAPTATIONS = [
+  {
+    file: "version/semver.ts",
+    why: "SC2012 — the `Number.*` statics are dynamic-only; the global is lowered statically.",
+    from: /Number\.parseInt\(/g,
+    to: "parseInt(",
+  },
+  {
+    file: "version/semver.ts",
+    why:
+      "SC1090 — under the repo's `noUncheckedIndexedAccess`, `s[i]` types as " +
+      "`string | undefined`, an index/result shape scriptc will not lower. `charAt` " +
+      'answers `""` where the index read `undefined`, and both comparisons here are ' +
+      "against a one-character literal, so neither branch changes.",
+    from: `  const head = token[0];`,
+    to: `  const head = token.charAt(0);`,
+  },
+  {
+    file: "version/semver.ts",
+    why: "SC1090 — as above, on the `~>1.2.3` spelling.",
+    from: `token[1] === ">"`,
+    to: `token.charAt(1) === ">"`,
+  },
+  {
+    file: "version/semver.ts",
+    why:
+      "SC1043 — a relational compare needs a narrowed operand, not a `string | number` union. " +
+      "`aNum === bNum` holds here, so both branches are exhaustive and the order is unchanged.",
+    from: `  if (a === b) return 0;\n  return a < b ? -1 : 1;\n}`,
+    to:
+      `  if (a === b) return 0;\n` +
+      `  if (typeof a === "number" && typeof b === "number") return a < b ? -1 : 1;\n` +
+      `  return String(a) < String(b) ? -1 : 1;\n}`,
+  },
+];
+
+rmSync(OUT, { recursive: true, force: true });
+
+const files = [];
+(function walk(dir) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) walk(path);
+    else if (entry.name.endsWith(".ts")) files.push(path);
+  }
+})(SRC);
+
+let rewritten = 0;
+let preserved = 0;
+
+for (const file of files) {
+  const rel = relative(SRC, file);
+  const modules = new Set();
+
+  const lines = readFileSync(file, "utf8")
+    .split("\n")
+    .map((line) => {
+      // `shims.ts` carries the *generated* stub bodies as string literals. Those
+      // are output, not code we compile: §12 marks the shim source exact, and
+      // rewriting it would change the files `enable` writes to a user's PATH.
+      const head = line.trimStart();
+      if (head.startsWith("`") || head.startsWith('"')) {
+        preserved += line.match(CALL_RE)?.length ?? 0;
+        CALL_RE.lastIndex = 0;
+        return line;
+      }
+      return line.replace(CALL_RE, (_, specifier) => {
+        modules.add(specifier);
+        rewritten++;
+        return identifierFor(specifier);
+      });
+    });
+
+  let source = lines.join("\n");
+  if (modules.size > 0) source = withImports(source, modules);
+
+  for (const { file: target, from, to } of ADAPTATIONS) {
+    if (rel !== target) continue;
+    const next = source.replace(from, to);
+    if (next === source) throw new Error(`adaptation for ${target} did not apply`);
+    source = next;
+  }
+
+  const dest = join(OUT, rel);
+  mkdirSync(dirname(dest), { recursive: true });
+  writeFileSync(dest, source);
+}
+
+/** `node:fs/promises` -> `__sc_node_fs_promises`. Prefixed so it cannot collide. */
+function identifierFor(specifier) {
+  return `__sc_${specifier.replaceAll(/[:/-]/g, "_")}`;
+}
+
+/**
+ * Put the imports below the file's own header comment rather than at line 1, so
+ * a diff against `src/` reads as an insertion and the module still opens with
+ * the paragraph that explains it.
+ */
+function withImports(source, modules) {
+  const imports = [...modules]
+    .sort()
+    .map((m) => `import * as ${identifierFor(m)} from ${JSON.stringify(m)};`)
+    .join("\n");
+
+  const lines = source.split("\n");
+  let at = 0;
+  if (lines[0]?.startsWith("#!")) at++;
+  while (at < lines.length && lines[at].trim() === "") at++;
+  if (lines[at]?.trimStart().startsWith("/*")) {
+    while (at < lines.length && !lines[at].includes("*/")) at++;
+    at++;
+  }
+  lines.splice(at, 0, imports);
+  return lines.join("\n");
+}
+
+console.log(
+  `${files.length} files -> ${OUT}\n` +
+    `  ${rewritten} getBuiltinModule call(s) rewritten to namespace imports\n` +
+    `  ${preserved} preserved verbatim inside generated-shim string literals\n` +
+    `  ${ADAPTATIONS.length} language-subset adaptation(s) applied`,
+);

--- a/scripts/scriptc/regex-repro.ts
+++ b/scripts/scriptc/regex-repro.ts
@@ -1,0 +1,30 @@
+/**
+ * Minimal, self-contained repro of the scriptc divergence that makes a compiled
+ * jup answer *wrong* rather than fail. Nothing here imports jup.
+ *
+ *   node --experimental-strip-types scripts/scriptc/regex-repro.ts
+ *   npx scriptc build scripts/scriptc/regex-repro.ts -o /tmp/repro && /tmp/repro
+ *
+ * A capture group that did not participate reads `""`, where ECMA-262
+ * (RegExp.prototype.exec, step 28) specifies `undefined`:
+ *
+ *   node     PARTIAL 4 => ["4","4",null,null]
+ *   scriptc  PARTIAL 4 => ["4","4","",""]
+ *
+ * `src/version/semver.ts` reads an absent component as "wildcard"
+ * (`isWildcard(match[2])`, and `match[1] ?? "="` on the operator path). `""` is
+ * not absent and not a wildcard, so it falls through to `toNumber("")` and every
+ * partial range — `^4`, `9.x`, `*`, `>=18 <21` — becomes a parse failure. The
+ * binary links, runs, exits 0, and reports those ranges invalid.
+ */
+
+const NUM = String.raw`0|[1-9]\d*`;
+const NUM_OR_X = String.raw`(?:${NUM}|x|X|\*)`;
+const PARTIAL_RE = new RegExp(
+  String.raw`^[v=]*(${NUM_OR_X})(?:\.(${NUM_OR_X}))?(?:\.(${NUM_OR_X}))?$`,
+);
+
+for (const input of ["10.0.0", "4", "9.x", "*", "18"]) {
+  const match = PARTIAL_RE.exec(input);
+  console.log(`PARTIAL ${input.padEnd(7)} =>`, JSON.stringify(match && [...match]));
+}

--- a/scripts/scriptc/try-build.mjs
+++ b/scripts/scriptc/try-build.mjs
@@ -1,0 +1,172 @@
+/**
+ * Try to compile jup to a native binary with scriptc, and report where it stops.
+ *
+ * Four stages, each of which prints its own verdict and none of which writes
+ * anything into the repository — the rewritten tree, the entries and the
+ * binaries all land under `<work>` (default `.scriptc-work/`, gitignored):
+ *
+ *   1. rewrite   `src/` -> a tree scriptc can parse (`codemod.mjs`)
+ *   2. coverage  the whole CLI: how many preflight errors, and in which files
+ *   3. build     the whole CLI, which is expected to fail; and `version/semver.ts`,
+ *                which is expected to succeed
+ *   4. verify    the semver binary against Node running the same source
+ *
+ * Stage 4 is the point of the script. Stage 3 succeeding is not evidence that
+ * the output is correct, and on scriptc 0.0.35 it is not: see `regex-repro.ts`.
+ *
+ * Usage: `node scripts/scriptc/try-build.mjs [--work=<dir>] [--scriptc=<bin>]`
+ * Requires Node >=24 and `scriptc` on PATH (or `--scriptc`).
+ */
+
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdirSync, statSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join, resolve } from "node:path";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO = resolve(HERE, "../..");
+
+const args = new Map(
+  process.argv.slice(2).map((a) => {
+    const eq = a.indexOf("=");
+    return eq === -1 ? [a.replace(/^--/, ""), ""] : [a.slice(2, eq), a.slice(eq + 1)];
+  }),
+);
+const WORK = resolve(args.get("work") || join(REPO, ".scriptc-work"));
+const SCRIPTC = args.get("scriptc") || "scriptc";
+const TREE = join(WORK, "src");
+
+mkdirSync(WORK, { recursive: true });
+
+/** Run scriptc, capturing both streams; a non-zero exit is data, not a crash. */
+function scriptc(...argv) {
+  const r = spawnSync(SCRIPTC, argv, { encoding: "utf8", cwd: WORK });
+  if (r.error) {
+    console.error(`\ncannot run ${SCRIPTC}: ${r.error.message}`);
+    console.error("install it with `npm i -g scriptc` (needs Node >=24), or pass --scriptc=<path>");
+    process.exit(2);
+  }
+  return { code: r.status ?? 1, out: `${r.stdout}${r.stderr}` };
+}
+
+function heading(n, text) {
+  console.log(`\n${"=".repeat(64)}\n${n}. ${text}\n${"=".repeat(64)}`);
+}
+
+// 1 -------------------------------------------------------------------------
+heading(1, "rewrite src/ into a tree scriptc can parse");
+console.log(
+  execFileSync(process.execPath, [join(HERE, "codemod.mjs"), join(REPO, "src"), TREE], {
+    encoding: "utf8",
+  }).trim(),
+);
+
+// The shipped entry (`src/bin.ts`) reaches main through `await import()` and
+// calls `enableCompileCache`; neither survives a static compile, so the CLI gets
+// an entry that only differs in those two lines.
+writeFileSync(
+  join(TREE, "entry-cli.ts"),
+  `import { runMain } from "./main.ts";\n\n` +
+    `const { code } = await runMain(process.argv.slice(2), { handover: true });\n` +
+    `if (code !== 0) process.exitCode = code;\n`,
+);
+
+// The one module that compiles today, driven through its real exports.
+writeFileSync(
+  join(TREE, "entry-semver.ts"),
+  `import { parse, satisfies, compare, isValidRange, major } from "./version/semver.ts";\n\n` +
+    `const [version = "10.12.1", range = "^10.0.0"] = process.argv.slice(2);\n` +
+    `const parsed = parse(version);\n` +
+    `console.log("parse:", parsed ? \`\${parsed.major}.\${parsed.minor}.\${parsed.patch}\` : "null");\n` +
+    `console.log("major:", major(version));\n` +
+    `console.log("isValidRange:", isValidRange(range));\n` +
+    `console.log("satisfies:", satisfies(version, range));\n` +
+    `console.log("compare vs 9.0.0:", compare(version, "9.0.0"));\n`,
+);
+
+// 2 -------------------------------------------------------------------------
+heading(2, "coverage: the whole CLI");
+const coverage = scriptc("coverage", join(TREE, "entry-cli.ts"));
+const errors = [...coverage.out.matchAll(/\/src\/([\w/.-]+\.ts):\d+/g)].map((m) => m[1]);
+const byFile = new Map();
+for (const file of errors) byFile.set(file, (byFile.get(file) ?? 0) + 1);
+
+console.log(coverage.out.split("\n").slice(0, 3).join("\n").trim() || "(no summary line)");
+if (byFile.size > 0) {
+  console.log(`\n${errors.length} preflight errors, by file:`);
+  for (const [file, n] of [...byFile].sort((a, b) => b[1] - a[1]).slice(0, 12)) {
+    console.log(`  ${String(n).padStart(4)}  ${file}`);
+  }
+}
+
+// 3 -------------------------------------------------------------------------
+heading(3, "build");
+const cli = scriptc("build", join(TREE, "entry-cli.ts"), "-o", join(WORK, "jup"));
+console.log(`whole CLI      -> ${cli.code === 0 ? "BUILT (unexpected!)" : "refused, as expected"}`);
+
+const semverBin = join(WORK, "jup-semver");
+const semver = scriptc("build", join(TREE, "entry-semver.ts"), "-o", semverBin);
+if (semver.code !== 0) {
+  console.log("version/semver -> FAILED");
+  console.log(semver.out.trim());
+  process.exit(1);
+}
+console.log(
+  `version/semver -> built, ${(statSync(semverBin).size / 1024).toFixed(0)} KB static` +
+    " (no embedded engine)",
+);
+
+// 4 -------------------------------------------------------------------------
+heading(4, "verify the binary against Node on the same source");
+
+const oracle = join(WORK, "oracle.mjs");
+writeFileSync(
+  oracle,
+  `import { parse, satisfies, compare, isValidRange, major } from ${JSON.stringify(join(REPO, "src/version/semver.ts"))};\n` +
+    `const [version, range] = process.argv.slice(2);\n` +
+    `const parsed = parse(version);\n` +
+    `console.log("parse:", parsed ? \`\${parsed.major}.\${parsed.minor}.\${parsed.patch}\` : "null");\n` +
+    `console.log("major:", major(version));\n` +
+    `console.log("isValidRange:", isValidRange(range));\n` +
+    `console.log("satisfies:", satisfies(version, range));\n` +
+    `console.log("compare vs 9.0.0:", compare(version, "9.0.0"));\n`,
+);
+
+const CASES = [
+  ["10.12.1", "^10.0.0"],
+  ["1.2.3-beta.1", ">=1.0.0"],
+  ["9.0.0", "9.x"],
+  ["0.0.1", "~0.0.1"],
+  ["4.1.0+sha224.abc", "^4"],
+  ["20.11.0", ">=18 <21"],
+  ["bogus", "^1"],
+  ["1.0.0-rc.10", "1.0.0-rc.2"],
+  ["2.0.0", "*"],
+  ["1.2.3-alpha.00000000000000000001", "^1.0.0-alpha"],
+  ["10.0.0-0", "^9.0.0-0"],
+];
+
+const run = (cmd, argv) => spawnSync(cmd, argv, { encoding: "utf8" }).stdout?.trim() ?? "";
+let diffs = 0;
+
+for (const [version, range] of CASES) {
+  const expected = run(process.execPath, ["--experimental-strip-types", oracle, version, range]);
+  const actual = run(semverBin, [version, range]);
+  const label = `${version} | ${range}`;
+  if (expected === actual) {
+    console.log(`  ok    ${label}`);
+    continue;
+  }
+  diffs++;
+  console.log(`  DIFF  ${label}`);
+  const e = expected.split("\n");
+  actual.split("\n").forEach((line, i) => {
+    if (line !== e[i]) console.log(`          node: ${e[i]}\n        native: ${line}`);
+  });
+}
+
+console.log(
+  `\n${CASES.length - diffs}/${CASES.length} agree with Node.` +
+    (diffs > 0 ? ` ${diffs} silently wrong — see scripts/scriptc/regex-repro.ts.` : ""),
+);
+process.exitCode = diffs > 0 ? 1 : 0;


### PR DESCRIPTION
## Goal

This PR is an experiment to see whether [scriptc](https://github.com/vercel-labs/scriptc) can compile `jup` into a native executable. It was tested with scriptc **0.0.35**.

To try it:

```sh
npm i -g scriptc          # requires Node.js 24 or newer
node scripts/scriptc/try-build.mjs
```

The script creates a temporary, adapted copy of `src/`, measures which files scriptc can compile, tries the build, and compares the compiled output with Node.js. All generated files go into `.scriptc-work/`, which is gitignored.

## What works

- The test harness and source-rewriting step work.
- A small set of compatibility rewrites lets scriptc get further without changing the intended behaviour. They are documented in `codemod.mjs`.
- `src/version/semver.ts` compiles into a fully static **603 KB** executable, compared with a **124 MB** Node.js executable.
- The differential test runs the same semver cases with Node.js and the compiled executable, so semantic differences are visible instead of being mistaken for a successful build.

## What is still missing

### 1. There is no scriptc equivalent of `process.getBuiltinModule`

`jup` deliberately accesses Node.js built-ins through `process.getBuiltinModule` instead of static `node:` imports. This keeps built-ins out of the warm-path module graph and is a project invariant.

scriptc currently supports built-ins through static imports such as `import * as fs from "node:fs"`, but does not provide `process.getBuiltinModule`. This affects **78 call sites** and produces **168 initial compiler errors**.

The experiment rewrites those calls to static imports so that we can test the rest of scriptc, but that rewrite is only suitable for this experiment and cannot be shipped in `jup`.

### 2. Several required built-in APIs are not implemented

After the import rewrite, **146 compiler errors** remain. The modules can be resolved, but APIs used by `jup` are missing, including:

- `URL.origin`, `URL.username`, `URL.password`, and `URL.canParse`
- `crypto.verify`, `crypto.createPublicKey`, and `crypto.timingSafeEqual`
- zlib stream constructors
- filesystem symlink and stream APIs
- `module.runMain`
- `util.styleText`

The most affected files are:

- `src/net/proxy.ts`: 30 errors
- `src/commands/shims.ts`: 19 errors
- `src/net/http.ts`: 15 errors
- `src/run/native.ts`: 12 errors
- `src/cache/tar.ts`: 11 errors

These APIs are needed for registry authentication, secure downloads, archive extraction, signatures, process startup, and shim creation. They are not optional features that can simply be removed from a useful `jup` build.

### 3. A compiled semver test runs, but gives incorrect results

Although `src/version/semver.ts` compiles and exits normally, the compiled executable disagrees with Node.js in **5 of 11** differential tests. For example:

```text
isValidRange("9.x")       Node.js: true   compiled: false
isValidRange("^4")        Node.js: true   compiled: false
isValidRange(">=18 <21")  Node.js: true   compiled: false
isValidRange("*")         Node.js: true   compiled: false
```

The standalone reproduction is `scripts/scriptc/regex-repro.ts`. A regular-expression capture group that did not participate in the match returns an empty string in the compiled program, while JavaScript requires `undefined`:

```text
PARTIAL_RE.exec("4")
Node.js:  ["4", "4", undefined, undefined]
compiled: ["4", "4", "", ""]
```

`jup`'s semver parser uses `undefined` to detect omitted version components. Returning `""` makes partial ranges fail to parse, which could cause `jup` to select the wrong package-manager version.

Because of this mismatch, the experiment intentionally exits with a non-zero status.

## Small compatibility rewrites used by the experiment

In addition to replacing `getBuiltinModule`, the derived source tree contains four documented adaptations for constructs scriptc cannot currently lower:

- `Number.parseInt`
- a relational comparison involving `string | number`
- indexed string access under `noUncheckedIndexedAccess`

These changes preserve the intended semantics and are only applied to `.scriptc-work/`; they do not modify the real `src/` tree.

The six `getBuiltinModule` occurrences inside string literals in `shims.ts` are intentionally left unchanged because they are generated source whose exact text is part of `jup`'s output contract.

## Current conclusion

The size of the fully static executable is promising, and this PR now provides a repeatable way to measure scriptc compatibility. However, `jup` cannot yet be built as a trustworthy scriptc executable because:

1. its required built-in loading mechanism is unavailable;
2. several security- and runtime-critical Node.js APIs are missing; and
3. the compiled regular-expression behaviour differs from JavaScript semantics.

Feedback from the scriptc maintainers would be especially helpful on whether these APIs are planned, whether there is a supported alternative to `process.getBuiltinModule`, and whether the regex mismatch is already known. `regex-repro.ts` can be used as a standalone upstream bug report.
